### PR TITLE
docs: add instructions for setting up the HTML document

### DIFF
--- a/docs/guides/page-setup-javascript.mdx
+++ b/docs/guides/page-setup-javascript.mdx
@@ -1,4 +1,4 @@
-Fabric client side JavaScript code should be loaded at the bottom of the `<body>` of the document with a preload link tag in the document `<head>`
+Fabric client-side JavaScript code should be loaded at the bottom of the `<body>` of the document with a preload link tag in the document `<head>`
 The URL should be the URL pointing to the JS file you published to Eik earlier.
 
 Create HTML `<link>` and `<script>` tags using the URL like so:

--- a/docs/guides/page-setup-javascript.mdx
+++ b/docs/guides/page-setup-javascript.mdx
@@ -1,0 +1,19 @@
+Fabric client side JavaScript code should be loaded at the bottom of the `<body>` of the document with a preload link tag in the document `<head>`
+The URL should be the URL pointing to the JS file you published to Eik earlier.
+
+Create HTML `<link>` and `<script>` tags using the URL like so:
+
+```html
+<html>
+<head>
+    ...
+    <link href="https://assets.finn.no/pkg/<eik.json name field>/<eik.json version field>/scripts.js" rel="preload" as="script" crossorigin>
+    ...
+</head>
+<body>
+    Your content here
+    <script src="https://assets.finn.no/pkg/<eik.json name field>/<eik.json version field>/scripts.js" type="module"></script>
+</body>
+</html>
+```
+

--- a/docs/guides/page-setup-podium.mdx
+++ b/docs/guides/page-setup-podium.mdx
@@ -1,0 +1,22 @@
+### Usage in a document
+
+In a Podium podlet or layout,
+your content will automatically be wrapped in an HTML document such that you can simply 
+implement the content that should be placed within the HTML document's `<body>` tag.
+
+```html
+<html>
+<head>
+    ...
+</head>
+<body>
+    You only need to implement the content here.
+</body>
+</html>
+```
+
+For this to work, you need to ensure that you are using the `podiumSend` method when rendering your content.
+
+```js
+(req, res) => res.podiumSend(`You only need to implement the content here.`);
+```

--- a/docs/guides/page-setup.mdx
+++ b/docs/guides/page-setup.mdx
@@ -1,0 +1,18 @@
+### Usage in a document
+
+Fabric should be loaded in the head of the document. The URL should be the URL pointing to the CSS file you published to Eik earlier.
+Create an HTML `link` tag with the URL like so:
+
+```html
+<html>
+<head>
+    ...
+    <link href="https://assets.finn.no/pkg/<eik.json name field>/<eik.json version field>/styles.css" rel="stylesheet" type="text/css">
+    ...
+</head>
+<body>
+    Your content here
+</body>
+</html>
+```
+

--- a/src/pages/guide-instructions.js
+++ b/src/pages/guide-instructions.js
@@ -39,6 +39,7 @@ export default function Instructions({ allGuides }) {
     const htmlTemplate = abstraction === 'html-template';
     const expressLayout = abstraction === 'express-layout';
     const expressPodlet = abstraction === 'express-podlet';
+    const podium = htmlTemplate || expressPodlet || expressLayout;
 
     const guides = {
       'eik.mdx': allGuides['eik.mdx'],
@@ -55,6 +56,9 @@ export default function Instructions({ allGuides }) {
       'express-layout.mdx': expressLayout ? allGuides['express-layout.mdx'] : undefined,
       'express-podlet.mdx': expressPodlet ? allGuides['express-podlet.mdx'] : undefined,
       'html-template.mdx': htmlTemplate ? allGuides['html-template.mdx'] : undefined,
+      'page-setup.mdx': !podium ? allGuides['page-setup.mdx'] : undefined,
+      'page-setup-podium.mdx': podium ? allGuides['page-setup-podium.mdx'] : undefined,
+      'page-setup-javascript.mdx': !podium && isCSFramework ? allGuides['page-setup-javascript.mdx'] : undefined,
     };
 
     const enabledGuides = Object.keys(guides).filter((guide) => guides[guide]);

--- a/src/pages/guide-setup.js
+++ b/src/pages/guide-setup.js
@@ -16,7 +16,7 @@ export default function GuideSetup() {
   const query = new URLSearchParams();
   if (platform) query.append('platform', platform);
   if (framework) query.append('framework', framework);
-  if (podium) query.append('podium', podium);
+  // if (podium) query.append('podium', podium);
   if (abstraction) query.append('abstraction', abstraction);
   if (clientSideFramework) query.append('csframework', clientSideFramework);
 


### PR DESCRIPTION
Adds either information about getting content automatically wrapped in the document template when using res.podiumSend 

![Screenshot 2021-11-10 at 14 33 51](https://user-images.githubusercontent.com/1177098/141122604-bb7a57c0-3352-4c63-85e9-eb306ac65b31.png)

or provides instructions for including link and script tags for those not using html-template/podium.

![Screenshot 2021-11-10 at 14 35 20](https://user-images.githubusercontent.com/1177098/141122745-d886e312-cc03-4613-973a-02446926add6.png)


