### PR TITLE
Doc tweaks

### DIFF
--- a/docs/guides/eik.mdx
+++ b/docs/guides/eik.mdx
@@ -102,7 +102,7 @@ files on the Eik server.
 ### Production ready files with Eik plugins
 
 The file located at `https://assets.finn.no/map/fabric/v1` is an import map. If you visit the link in a browser, you'll
-see that `@fabric-ds/css` is mapped to `https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css`. Now that we've
+see that `@fabric-ds/css` is mapped to `https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css`. Now that we've
 setup Eik and added this import map in `eik.json`, when we run our build command, PostCSS, instead of inlining the
 Fabric CSS code, is going to replace references to `@fabric-ds/css` in import statements with value found in the import
 map instead. It's this mechanism that we use to line everyone up on the same version of Fabric across all of Finn. With
@@ -118,7 +118,7 @@ npm run build:css
 And check `./dist/styles.css` and make sure that it contains a single line:
 
 ```css:styles.css
-@import 'https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css';
+@import 'https://assets.finn.no/pkg/@fabric-ds/css/v1/fabric.min.css';
 ```
 
 ### Publishing to the Eik server

--- a/docs/guides/vue.mdx
+++ b/docs/guides/vue.mdx
@@ -18,15 +18,16 @@ specify which component(s) you want to use as part of an import statement.
 
 Refer to the Fabric Vue docs to learn more about the various components and how to use them.
 
-In the following example, we import the button component
+In the following example, we import and install the button component
 
 ```js
 import { Button } from '@fabric-ds/vue';
+app.use(Button)
 ```
 
 #### Using components
 
-Once imported, components can then be used like any other Vue component in your code. Refer to the docs for component
+Once installed, components can then be used anywhere in your app like any normal Vue component. Refer to the docs for component
 usage.
 
 ```jsx


### PR DESCRIPTION
- Change the Eik section to refer to v1
- Align wording in the Vue docs with how the exports would get used in an app